### PR TITLE
Fix a bug where routes with wildcards would always be matched

### DIFF
--- a/core/Router.php
+++ b/core/Router.php
@@ -25,8 +25,6 @@ class Router
   }
 
   public function direct($uri, $requestMethod) {
-
-
     $route = $this->matchRoute($this->routes[$requestMethod], $uri);
 
     if(!is_null($route)) {
@@ -61,35 +59,29 @@ class Router
      */
   private function matchRoute($routes, $uri)
   {
-
-      $uriParts = explode('/', $uri);
+        $uriParts = explode('/', $uri);
         foreach ($routes as $route => $routeData) {
             $routeParts = explode('/', $route);
+
             if (count($uriParts) !== count($routeParts)) {
                 continue;
             }
 
-            $matched = false;
             for ($i = 0; $i < count($uriParts); $i++) {
-              if ($uriParts[$i] === $routeParts[$i]) {
-                $matched = true;
-                continue;
-              }
-
-              if (false !== strpos($routeParts[$i], '{') && $uriParts[$i-1] === $routeParts[$i-1]) {
-                $paramName = trim($routeParts[$i],'{\}');
-                $matched = true;
-                $routeData['parameters'][$paramName] = $uriParts[$i];
-                continue;
-              }
-
-                else {
-                    $matched = false;
+                if ($uriParts[$i] === $routeParts[$i]) {
+                    continue;
                 }
+
+                if (false !== strpos($routeParts[$i], '{')) {
+                    $paramName = trim($routeParts[$i], '{\}');
+                    $routeData['parameters'][$paramName] = $uriParts[$i];
+                    continue;
+                }
+
+                continue 2;
             }
-            if ($matched) {
-                return $routeData;
-            }
+
+            return $routeData;
         }
 
         return null;
@@ -101,6 +93,6 @@ class Router
     if(!method_exists($c, $method)) {
       throw new \Exception('No method');
     }
-    return $c->$method($params);
+    return $c->$method(...array_values($params));
   }
 }

--- a/core/Router.php
+++ b/core/Router.php
@@ -92,6 +92,6 @@ class Router
     if(!method_exists($c, $method)) {
       throw new \Exception('No method');
     }
-    return $c->$method(...array_values($params));
+    return $c->$method(...$params);
   }
 }

--- a/core/Router.php
+++ b/core/Router.php
@@ -73,8 +73,7 @@ class Router
                 }
 
                 if (false !== strpos($routeParts[$i], '{')) {
-                    $paramName = trim($routeParts[$i], '{\}');
-                    $routeData['parameters'][$paramName] = $uriParts[$i];
+                    $routeData['parameters'][] = $uriParts[$i];
                     continue;
                 }
 


### PR DESCRIPTION
In essence. we inverted the clause by mistake.
Starting with a true statement will always simulate || instead
of && that we needed for this task. Additionallly, we
simplified the syntax by employinh continues and breaking
the loop.